### PR TITLE
fix(setup): skip creating symlink if already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ After executing setup.sh, there is some chore that needs to be done manually.
 
 Add this code block to ~/.bash_profile to activate Fish-shell.
 ```sh
+eval "$(pyenv init --path)"
+
 # Change shell
 FISH_SHELL="/usr/local/bin/fish"
 if [ -x "$FISH_SHELL" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -34,7 +34,11 @@ mkdir -p $BACKUP_DIR/.config/{fish,karabiner,nvim}
 
 for file in "${FILES[@]}"
 do
-  if [ -e $HOME/$file ]; then
+  if [[ -L $HOME/$file ]]; then
+    continue
+  fi
+
+  if [[ -e $HOME/$file ]]; then
     cp -pr $HOME/$file $BACKUP_DIR/$file
     rm -rf $HOME/$file
   fi


### PR DESCRIPTION
When symbolic already exists, it skips the process